### PR TITLE
Perform maintainance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,21 @@ env:
   global:
     - "IMAGE=irap/docker-debian-ansible:stretch"
   matrix:
-    - "ANSIBLE_VERSION=2.4.3.0"
-    - "ANSIBLE_VERSION=2.3.3.0"
-    - "ANSIBLE_VERSION=2.2.3.0"
-    - "ANSIBLE_VERSION=2.1.6.0"
+    - "NTH_SUPPORTED_ANSIBLE_VERSION=1"
+    - "NTH_SUPPORTED_ANSIBLE_VERSION=2"
+    - "NTH_SUPPORTED_ANSIBLE_VERSION=3"
+    - "NTH_SUPPORTED_ANSIBLE_VERSION=4"
 language: "python"
 notifications:
   email: false
 python:
   - "2.7"
 script:
-  - "wget -O ${PWD}/run.sh https://raw.githubusercontent.com/pari-/docker-debian-ansible/master/run.sh"
-  - "chmod +x ${PWD}/run.sh"
-  - "${PWD}/run.sh"
+    - "wget -O ${PWD}/run.sh https://raw.githubusercontent.com/pari-/docker-debian-ansible/master/run.sh"
+    - "wget -O ${PWD}/extract_ansible_version.sh https://raw.githubusercontent.com/pari-/docker-debian-ansible/master/extract_ansible_version.sh"
+    - "wget -O ${PWD}/Dockerfile https://raw.githubusercontent.com/pari-/docker-debian-ansible/master/debian/stretch/Dockerfile"
+    - "chmod +x ${PWD}/run.sh"
+    - "chmod +x ${PWD}/extract_ansible_version.sh"
+    - 'export ANSIBLE_VERSION=$(./extract_ansible_version.sh Dockerfile ${NTH_SUPPORTED_ANSIBLE_VERSION}) && ${PWD}/run.sh'
 services: "docker"
 sudo: "required"

--- a/README.md
+++ b/README.md
@@ -19,12 +19,7 @@ An Ansible role which installs and configures NodeJS from NodeSource
 
 Currently this role is developed for and tested on Debian GNU/Linux (release: stretch). It is assumed to work on other Debian distributions as well.
 
-Ansible version compatibility:
-
-- __2.4.3.0__ (current version in use for development of this role)
-- 2.3.3.0
-- 2.2.3.0
-- 2.1.6.0
+Ansible version compatibility: [Dockerfile](https://github.com/pari-/docker-debian-ansible/blob/master/debian/stretch/Dockerfile)
 
 ## Example
 
@@ -57,9 +52,9 @@ variable | default | notes
 `repo_list[0]['repo']` | `deb https://deb.nodesource.com/{{ nodejs_version }} {{ nodejs_default_release }} main` | `Source string for the repositories`
 `repo_list[0]['repo']['key']['id']` | `68576280` | `Identifier of (the repository) key`
 `repo_list[0]['repo']['key']['keyserver']` | `keyserver.ubuntu.com` | `Keyserver to retrieve the key (for the repository) from`
-`supported_distro_list` | `['jessie', 'stretch']` | `A list of distribution releases this role supports`
+`supported_distro_list` | `['stretch']` | `A list of distribution releases this role supports`
 `update_cache` | `yes` | `Run the equivalent of apt-get update before the operation`
-`version` | `node_8.x` | `Version of the 'nodejs'-package that is to be installed`
+`version` | `node_10.x` | `Version of the 'nodejs'-package that is to be installed`
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,6 @@ nodejs_repo_list:
       id: "68576280"
       keyserver: "keyserver.ubuntu.com"
 nodejs_supported_distro_list:
-  - "jessie"
   - "stretch"
 nodejs_update_cache: "yes"
-nodejs_version: "node_8.x"
+nodejs_version: "node_10.x"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,5 +13,4 @@ galaxy_info:
   platforms:
     - name: "Debian"
       versions:
-        - "jessie"
         - "stretch"


### PR DESCRIPTION
Integrate new 'Ansible Version'-testing mechanism
Drop Jessie support
Bump default 'nodejs_version' from 8 to 10